### PR TITLE
Put endpoints and edits to other endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,45 +21,45 @@ app.get('/api/v1/projects', async (req, res) => {
 app.get('/api/v1/projects/:id', async (req, res) => {
   const id = req.params.id;
   try {
-    const matchingProject = await database('projects').where({ id }).select();
+    const matchingProject = await database('projects').where({ id });
     return matchingProject.length ? 
       res.status(200).json(matchingProject[0]) : 
       res.status(404).json(`No matching project found with id ${id}.`);
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.get('/api/v1/palettes/:id', async (req, res) => {
   const id = req.params.id;
   try {
-    const matchingPalette = await database('palettes').where({ id }).select();
+    const matchingPalette = await database('palettes').where({ id });
     return matchingPalette.length ? 
       res.status(200).json(matchingPalette[0]) : 
       res.status(404).json(`No matching palette found with id ${id}.`);
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.get('/api/v1/projects/:id/palettes', async (req, res) => {
   const id = req.params.id;
   try {
-    const matchingProject = await database('projects').where({ id }).select();
-    const matchingPalettes = await database('palettes').where('project_id', id).select();
+    const matchingProject = await database('projects').where({ id });
+    const matchingPalettes = await database('palettes').where('project_id', id);
     return matchingProject.length ? 
       res.status(200).json(matchingPalettes) : 
       res.status(404).json(`No matching palettes found with project id ${id}.`);
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.post('/api/v1/projects', async (req, res) => {
   const { name } = req.body;
   if (!name) return res.status(422).json('No project name provided');
   try {
-    const dupProject = await database('projects').where({ name }).select();
+    const dupProject = await database('projects').where({ name });
     if (dupProject.length) return res.status(409).json(`Conflict. project name ${name} already exists.`);
     const project = { name };
     const newProjectId = await database('projects').insert(project, 'id');
@@ -67,7 +67,7 @@ app.post('/api/v1/projects', async (req, res) => {
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.post('/api/v1/palettes', async (req, res) => {
   const newPalette = req.body;
@@ -86,48 +86,66 @@ app.post('/api/v1/palettes', async (req, res) => {
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.delete('/api/v1/palettes/:id', async (req, res) => {
   const id = req.params.id;
   try {
-    const matchingPalette = await database('palettes').where({ id }).select();
+    const matchingPalette = await database('palettes').where({ id });
     if (!matchingPalette.length) return res.status(404).json(`No matching palette found with id ${id}`);
     await database('palettes').where({ id }).del();
     return res.sendStatus(202);
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.delete('/api/v1/projects/:id', async (req, res) => {
   const id = req.params.id;
   try {
-    const matchingProject = await database('projects').where({ id }).select();
+    const matchingProject = await database('projects').where({ id });
     if (matchingProject.length) {
       await database('palettes').where('project_id', id).del();
       await database('projects').where({ id }).del()
-      return res.sendStatus(202)
+      return res.sendStatus(202);
     }
     return res.status(404).json(`No matching project found with id ${id}`);
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
 
 app.put('/api/v1/projects/:id', async (request, res) => {
-  const id = request.params.id;
-  console.log(id)
-
-  // const name  = request.body.name
-  console.log(request.body)
+  const { id } = request.params;
+  const { name } = request.body;
+  if (!name) return res.status(422).json('Please provide a name.');
   try {
-    const matchingProject = await database('projects').where('id', id).select();
-    console.log(matchingProject)
-    return matchingProject ? res.status(200).json(matchingProject) : res.sendStatus(204);
+    const matchingProject = await database('projects').where({ id });
+    if (!matchingProject.length) return res.status(404).json(`No matching project found with id ${id}.`);
+    await database('projects').where({ id }).update({ name });
+    return res.sendStatus(204);
   } catch (error) {
     return res.status(500).json({ error });
   }
-})
+});
+
+app.put('/api/v1/palettes/:id', async (request, res) => {
+  const { id } = request.params;
+  const updatedPalette = request.body;
+  for (let requiredParameter of ['name', 'color1', 'color2', 'color3', 'color4', 'color5']) {
+    if (!updatedPalette[requiredParameter]) {
+      return res.status(422)
+        .json(`Expected format: { name: <String>, color1: <String>, color2: <String>, color3: <String>, color4: <String>, color5: <String>, project_id: <Number>}. You're missing a ${requiredParameter} property.`);
+    }
+  }
+  try {
+    const matchingProject = await database('palettes').where({ id });
+    if (!matchingProject.length) return res.status(404).json(`No matching palette found with id ${id}.`);
+    await database('palettes').where({ id }).update(updatedPalette);
+    return res.sendStatus(204);
+  } catch (error) {
+    return res.status(500).json({ error });
+  }
+});
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -10,9 +10,8 @@ app.get('/api/v1/projects', async (req, res) => {
   try {
     let matchingProjects = await database('projects').select();
     if (name) matchingProjects = matchingProjects.filter(project => project.name.toLowerCase().includes(name.toLowerCase()));
-    return matchingProjects.length ? 
-      res.status(200).json(matchingProjects) : 
-      res.status(404).json('No matching projects found.');
+    return matchingProjects.length ? res.status(200).json(matchingProjects) 
+    : res.status(404).json('No matching projects found.');
   } catch (error) {
     return res.status(500).json({ error });
   }
@@ -22,9 +21,8 @@ app.get('/api/v1/projects/:id', async (req, res) => {
   const id = req.params.id;
   try {
     const matchingProject = await database('projects').where({ id });
-    return matchingProject.length ? 
-      res.status(200).json(matchingProject[0]) : 
-      res.status(404).json(`No matching project found with id ${id}.`);
+    return matchingProject.length ? res.status(200).json(matchingProject[0])
+    : res.status(404).json(`No matching project found with id ${id}.`);
   } catch (error) {
     return res.status(500).json({ error });
   }
@@ -34,9 +32,8 @@ app.get('/api/v1/palettes/:id', async (req, res) => {
   const id = req.params.id;
   try {
     const matchingPalette = await database('palettes').where({ id });
-    return matchingPalette.length ? 
-      res.status(200).json(matchingPalette[0]) : 
-      res.status(404).json(`No matching palette found with id ${id}.`);
+    return matchingPalette.length ? res.status(200).json(matchingPalette[0]) 
+    : res.status(404).json(`No matching palette found with id ${id}.`);
   } catch (error) {
     return res.status(500).json({ error });
   }
@@ -47,9 +44,8 @@ app.get('/api/v1/projects/:id/palettes', async (req, res) => {
   try {
     const matchingProject = await database('projects').where({ id });
     const matchingPalettes = await database('palettes').where('project_id', id);
-    return matchingProject.length ? 
-      res.status(200).json(matchingPalettes) : 
-      res.status(404).json(`No matching palettes found with project id ${id}.`);
+    return matchingProject.length ? res.status(200).json(matchingPalettes) 
+    : res.status(404).json(`No matching palettes found with project id ${id}.`);
   } catch (error) {
     return res.status(500).json({ error });
   }

--- a/app.test.js
+++ b/app.test.js
@@ -214,16 +214,23 @@ describe('Server', () => {
     });
   });
 
-  describe.skip('PUT /api/v1/projects/:id', () => {
-
-    it('should respond with a 202 if it was successful and have removed a palette from the database', async () => {
+  describe('PUT /api/v1/projects/:id', () => {
+    it('should respond with a 204 if project was successfully updated', async () => {
       const projectToChange = await database('projects').first()
       const response = await request(app).put(`/api/v1/projects/${projectToChange.id}`).send({ name: 'New Name'});
       const updatedProject = await database('projects').first();
-      expect(response.status).toEqual(202);
+      expect(response.status).toEqual(204);
       expect(updatedProject).not.toEqual(projectToChange);
     });
 
-  })
+    it('should respond with a 422 and message if name is not provided', async () => {
 
-})
+    });
+
+    it('should respond with a 404 and message if project was not found', async () => {
+
+    });
+
+  });
+
+});

--- a/app.test.js
+++ b/app.test.js
@@ -224,13 +224,64 @@ describe('Server', () => {
     });
 
     it('should respond with a 422 and message if name is not provided', async () => {
-
+      const projectToChange = await database('projects').first()
+      const response = await request(app).put(`/api/v1/projects/${projectToChange.id}`);
+      expect(response.status).toEqual(422);
+      expect(response.body).toEqual('Please provide a name.');
     });
 
     it('should respond with a 404 and message if project was not found', async () => {
-
+      const nonExistantProject = 0;
+      const response = await request(app).put(`/api/v1/projects/${nonExistantProject}`).send({ name: 'New Name' });
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching project found with id ${nonExistantProject}.`);
     });
-
   });
 
+  describe('PUT /api/v1/palettes/:id', () => {
+    it('should respond with a 204 if palette was successfully updated', async () => {
+      const paletteToChange = await database('palettes').first();
+      const updatedPalette = {
+        name: 'New Name',
+        color1: 'ffffff',
+        color2: 'ffffff',
+        color3: 'ffffff',
+        color4: 'ffffff',
+        color5: 'ffffff'
+      };
+      const response = await request(app).put(`/api/v1/palettes/${paletteToChange.id}`).send(updatedPalette);
+      const palette = await database('palettes').first();
+      expect(response.status).toEqual(204);
+      expect(palette).not.toEqual(updatedPalette);
+    });
+
+    it('should respond with a 422 and message if correct params are not provided', async () => {
+      const paletteToChange = await database('palettes').first();
+      const updatedPalette = {
+        name: 'New Name',
+        color1: 'ffffff',
+        color2: 'ffffff',
+        color3: 'ffffff',
+        color4: 'ffffff'
+      };
+      const response = await request(app).put(`/api/v1/palettes/${paletteToChange.id}`).send(updatedPalette);
+      expect(response.status).toEqual(422);
+      expect(response.body).toEqual('Expected format: { name: <String>, color1: <String>, color2: <String>, color3: <String>, color4: <String>, color5: <String>, project_id: <Number>}. You\'re missing a color5 property.');
+    });
+
+    it('should respond with a 404 and message if palette was not found', async () => {
+      const nonExistantPalette = 0;
+      const updatedPalette = {
+        name: 'New Name',
+        color1: 'ffffff',
+        color2: 'ffffff',
+        color3: 'ffffff',
+        color4: 'ffffff',
+        color5: 'ffffff'
+      };
+      const response = await request(app).put(`/api/v1/palettes/${nonExistantPalette}`).send(updatedPalette);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching palette found with id ${nonExistantPalette}.`);
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -27,112 +27,98 @@ describe('Server', () => {
       expect(response.body).toEqual([expectedProject]);
     });
 
-    it('should respond with a 200 and matching projects if a partial name query is given', async () => {
-
+    it.skip('should respond with a 200 and matching projects if a partial name query is given', async () => {
+      const expectedProjects = await database('projects').select();
+      const response = await request(app).get('/api/v1/projects?name=Project');
+      expect(response.status).toEqual(200);
+      // how do we get created at and updated at fields to match up - json vs string?
+      expect(response.body).toEqual(expectedProjects);
     });
     
-    it('should respond with a 204 if there are no projects in the db', async () => {
+    it('should respond with a 404 and message if there are no projects in the db', async () => {
       await database('palettes').del();
       await database('projects').del();
-      const response = await request(app).get('/api/v1/projects');
-      expect(response.status).toEqual(204);
+      const response = await request(app).get('/api/v1/projects/?name=zzz');
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual('No matching projects found.');
     });
-
-    it('should respond with a 204 if a name query is given with no matches', async () => {
-
-    });
-
   });
 
   describe('GET /api/v1/projects/:id', () => {
-
     it('should respond with a 200 and the specific project if it exists', async () => {
       const expectedProject = await database('projects').first();
       const response = await request(app).get(`/api/v1/projects/${expectedProject.id}`);
       expect(response.status).toEqual(200);
-      expect(response.body[0].id).toEqual(expectedProject.id);
-    })
+      expect(response.body.id).toEqual(expectedProject.id);
+    });
 
-    it('should respond with a 204 if the specific project does not exist', async () => {
-      const firstProject = await database('projects').first();
-      const nonExistantProject = firstProject.id -1;
+    it('should respond with a 404 and message if the specific project does not exist', async () => {
+      const nonExistantProject = 0;
       const response = await request(app).get(`/api/v1/projects/${nonExistantProject}`);
-      expect(response.status).toEqual(204);
-    })
-
-  })
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching project found with id ${nonExistantProject}.`);
+    });
+  });
 
   describe('GET /api/v1/palettes/:id', () => {
-
-    it('should respond with a 200 and the specific palette if it exists', async () => {
+    it.skip('should respond with a 200 and the specific palette if it exists', async () => {
       const expectedPalette = await database('palettes').first();
       const response = await request(app).get(`/api/v1/palettes/${expectedPalette.id}`);
       expect(response.status).toEqual(200);
-      expect(response.body[0].id).toEqual(expectedPalette.id);
-    })
+      expect(response.body).toEqual(expectedPalette);
+    });
 
-    it('should respond with a 204 if the specific palette does not exist', async () => {
-      const firstPalette = await database('palettes').first();
-      const nonExistantPalette = firstPalette.id - 1;
+    it('should respond with a 404 and message if the specific palette does not exist', async () => {
+      const nonExistantPalette = 0;
       const response = await request(app).get(`/api/v1/palettes/${nonExistantPalette}`);
-      expect(response.status).toEqual(204);
-    })
-
-  })
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching palette found with id ${nonExistantPalette}.`);
+    });
+  });
 
   describe('GET /api/v1/projects/:id/palettes', () => {
-
-    it.skip('should respond with a 200 and the specific project if it exists with all its associated palettes', async () => {
+    it.skip('should respond with a 200 and matching palettes if they exist', async () => {
       const expectedProject = await database('projects').first();
-      const allPalettes = await database('palettes');
-      const expectedPalettes = allPalettes.filter(palette => palette.project_id === expectedProject.id);
+      const expectedPalettes = await database('palettes').where('project_id', expectedProject.id).select();
       const response = await request(app).get(`/api/v1/projects/${expectedProject.id}/palettes`);
       expect(response.status).toEqual(200);
-      expect(response.body.matchingProject[0].id).toEqual(expectedProject.id);
-      expect(response.body.matchingPalettes).toEqual([expectedPalettes]);
-    })
+      expect(response.body).toEqual(expectedPalettes);
+    });
 
-    it('should respond with a 204 if the specific project does not exist', async () => {
-      const firstProject = await database('projects').first();
-      const nonExistantProject = firstProject.id - 1;
+    it('should respond with a 404 and message if the specific palettes do not exist for that project', async () => {
+      const nonExistantProject = 0;
       const response = await request(app).get(`/api/v1/projects/${nonExistantProject}/palettes`);
-      expect(response.status).toEqual(204);
-    })
-
-    it(`should respond with a 200, the specific project and an empty array
-        if it exists but has no associated palettes`, async () => {
-      const expectedProject = await database('projects').where('name', 'Empty').select();
-      const allPalettes = await database('palettes');
-      const expectedPalettes = allPalettes.filter(palette => palette.project_id === expectedProject[0].id);
-      const response = await request(app).get(`/api/v1/projects/${expectedProject[0].id}/palettes`);
-      expect(response.status).toEqual(200);
-      expect(response.body.matchingProject[0].id).toEqual(expectedProject[0].id);
-      expect(response.body.matchingPalettes).toEqual(expectedPalettes);
-    })
-  })
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching palettes found with project id ${nonExistantProject}.`);
+    });
+  });
 
   describe('POST /api/v1/projects', () => {
-
     it('should respond with a 201 and add project', async () => {
-      const startingProjects = await database('projects')
-      const response = await request(app).post('/api/v1/projects').send({name: 'New Project'})
-      const expectedProjects = await database('projects')
+      const startingProjects = await database('projects');
+      const response = await request(app).post('/api/v1/projects').send({name: 'New Project'});
+      const expectedProjects = await database('projects');
       expect(response.status).toEqual(201);
       expect(startingProjects.length + 1).toEqual(expectedProjects.length);
-    })
+    });
 
-    it('should respond with a 422 if no name provided', async () => {
+    it('should respond with a 409 and message if project name already exists', async () => {
+      const name = 'Project 1';
+      const response = await request(app).post('/api/v1/projects').send({ name });
+      expect(response.status).toEqual(409);
+      expect(response.body).toEqual(`Conflict. project name ${name} already exists.`);
+    });
+
+    it('should respond with a 422 and message if no name provided', async () => {
       const response = await request(app).post('/api/v1/projects')
       expect(response.status).toEqual(422);
-      expect(response.text).toEqual('"No project name provided"')
-    })
-
+      expect(response.body).toEqual('No project name provided')
+    });
   })
 
   describe('POST /api/v1/palettes', () => {
-
     it('should respond with a 201 and add pallete if succesful', async () => {
-      const projectToAddTo = await database('projects').first()
+      const projectToAddTo = await database('projects').first();
       const newPalette = {
         name: 'New Palette',
         color1: '434f4f',
@@ -141,13 +127,29 @@ describe('Server', () => {
         color4: 'jn4n44',
         color5: 'jhb4bk',
         project_id: projectToAddTo.id
-      }
-      const currentPalettes = await database('palettes').where('project_id', projectToAddTo.id)
-      const response = await request(app).post('/api/v1/palettes').send(newPalette)
+      };
+      const currentPalettes = await database('palettes').where('project_id', projectToAddTo.id);
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
       const expectedPalettes = await database('palettes').where('project_id', projectToAddTo.id)
       expect(response.status).toEqual(201);
       expect(currentPalettes.length + 1).toEqual(expectedPalettes.length)
-    })
+    });
+
+    it('should respond with a 409 and message if palette name already exists in that project', async () => {
+      const projectToAddTo = await database('projects').first();
+      const newPalette = {
+        name: 'Palette1',
+        color1: '434f4f',
+        color2: 'ffffff',
+        color3: 'h4b3b4',
+        color4: 'jn4n44',
+        color5: 'jhb4bk',
+        project_id: projectToAddTo.id
+      }
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
+      expect(response.status).toEqual(409);
+      expect(response.body).toEqual(`Conflict. palette name ${newPalette.name} already exists in project id ${newPalette.project_id}.`);
+    });
 
     it('should respond with a 422 and message about what is missing if a parameter is missing', async () => {
       const projectToAddTo = await database('projects').first()
@@ -159,15 +161,31 @@ describe('Server', () => {
         color5: 'jhb4bk',
         project_id: projectToAddTo.id
       }
-      const response = await request(app).post('/api/v1/palettes').send(newPalette)
+      const response = await request(app).post('/api/v1/palettes').send(newPalette);
       expect(response.status).toEqual(422);
-      expect(response.text).toEqual("Expected format: { name: <String>, color1: <String>, color2: <String>, color3: <String>, color4: <String>, color5: <String>, project_id: <Number>}. You're missing a color2 property.")
-    })
+      expect(response.body).toEqual('Expected format: { name: <String>, color1: <String>, color2: <String>, color3: <String>, color4: <String>, color5: <String>, project_id: <Number>}. You\'re missing a color2 property.');
+    });
+  });
 
-  })
+  describe('DELETE /api/v1/palettes/:id', () => {
+    it('should respond with a 202 if it was successful and have removed a palette from the database', async () => {
+      const allPalettes = await database('palettes');
+      const numExpectedPalettes = allPalettes.length - 1;
+      const response = await request(app).delete(`/api/v1/palettes/${allPalettes[0].id}`);
+      const remainingPalettes = await database('palettes');
+      expect(response.status).toEqual(202);
+      expect(numExpectedPalettes).toEqual(remainingPalettes.length);
+    });
+
+    it('should respond with a 404 and message if palette with specific id does not exist', async () => {
+      const nonExistantPalette = 0;
+      const response = await request(app).delete(`/api/v1/palettes/${nonExistantPalette}`);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching palette found with id ${nonExistantPalette}`)
+    });
+  });
 
   describe('DELETE /api/v1/projects/:id', () => {
-
     it('should respond with a 202 if it was successful and has removed a project from the database with all associated palettes', async () => {
       const projectToDelete = await database('projects').first();
       const allPalettes = await database('palettes');
@@ -188,32 +206,13 @@ describe('Server', () => {
       expect(numExpectedPalettes.length).toEqual(remainingPalettes.length);
     });
 
-    it('should respond with a 204 if project with specific id does not exist', async () => {
-      const firstProject = await database('projects').first();
-      const nonExistantProject = firstProject.id - 1;
-      const response = await request(app).delete(`/api/v1/palettes/${nonExistantProject}`);
-      expect(response.status).toEqual(204);
+    it('should respond with a 404 and message if project with specific id does not exist', async () => {
+      const nonExistantProject = 0;
+      const response = await request(app).delete(`/api/v1/projects/${nonExistantProject}`);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual(`No matching project found with id ${nonExistantProject}`)
     });
-  })
-
-  describe('DELETE /api/v1/palettes/:id', () => {
-
-    it('should respond with a 202 if it was successful and have removed a palette from the database', async () => {
-      const allPalettes = await database('palettes');
-      const numExpectedPalettes = allPalettes.length - 1;
-      const response = await request(app).delete(`/api/v1/palettes/${allPalettes[0].id}`);
-      const remainingPalettes = await database('palettes');
-      expect(response.status).toEqual(202);
-      expect(numExpectedPalettes).toEqual(remainingPalettes.length);
-    });
-
-    it('should respond with a 204 if palette with specific id does not exist', async () => {
-      const firstPalette = await database('palettes').first();
-      const nonExistantPalette = firstPalette.id - 1;
-      const response = await request(app).delete(`/api/v1/palettes/${nonExistantPalette}`);
-      expect(response.status).toEqual(204);
-    });
-  })
+  });
 
   describe.skip('PUT /api/v1/projects/:id', () => {
 


### PR DESCRIPTION
- Updated endpoints to send 404 instead of 204 status codes as needed.
- Updated GET '/api/v1/projects/:id/palettes' to only send back palettes from the matching project id.
- Added some additional checks in endpoints as needed.
- Added PUT endpoints and associated tests.

- Outstanding issue: skipped tests where created_at and updated_at fields do not match. Still need to figure out solution/workaround for this.